### PR TITLE
refactor: consistent slash command structure

### DIFF
--- a/src/commands/slash/anony.ts
+++ b/src/commands/slash/anony.ts
@@ -6,21 +6,19 @@ import type { SlashCommand } from "../../handlers/slashCommands.handler";
 const slashCommand: SlashCommand = {
   name: ANONY_CONSTANTS.name,
   description: ANONY_CONSTANTS.description,
-  type: "command",
-  builder: (command) =>
-    command
-      .addStringOption((option) =>
-        option
-          .setName(ANONY_CONSTANTS.subCommandTitleName)
-          .setDescription(ANONY_CONSTANTS.subCommandTitleDescription)
-          .setRequired(true),
-      )
-      .addStringOption((option) =>
-        option
-          .setName(ANONY_CONSTANTS.subCommandMessageName)
-          .setDescription(ANONY_CONSTANTS.subCommandMessageDescription)
-          .setRequired(true),
-      ),
+  options: [
+    {
+      name: ANONY_CONSTANTS.subCommandTitleName,
+      description: ANONY_CONSTANTS.subCommandTitleDescription,
+      required: true,
+    },
+    {
+      name: ANONY_CONSTANTS.subCommandMessageName,
+      description: ANONY_CONSTANTS.subCommandMessageDescription,
+      required: true,
+    },
+  ],
+
   async execute(client: Client, interaction: CommandInteraction) {
     const channel = client.channels.cache.get(
       process.env.ANONYMOUS_APPROVAL_CHANNEL_ID,

--- a/src/commands/slash/ping.ts
+++ b/src/commands/slash/ping.ts
@@ -4,11 +4,7 @@ import type { SlashCommand } from "../../handlers/slashCommands.handler";
 const slashCommand: SlashCommand = {
   name: "ping",
   description: PING_CONSTANTS.description,
-  type: "command",
-  builder: (command) =>
-    command.addStringOption((option) =>
-      option.setName("test").setDescription("test"),
-    ),
+  options: [{ name: "test", description: "test", required: true }],
   execute: async (_client, interaction) => {
     await interaction.reply(PING_CONSTANTS.pong);
   },

--- a/src/commands/slash/role.ts
+++ b/src/commands/slash/role.ts
@@ -15,7 +15,6 @@ import type { SlashCommand } from "../../handlers/slashCommands.handler";
 const slashCommand: SlashCommand = {
   name: ROLE_CONSTANTS.name,
   description: ROLE_CONSTANTS.description,
-  type: "command",
   async execute(_client: Client, interaction: CommandInteraction) {
     if (!interaction.inCachedGuild()) {
       await interaction.reply(

--- a/src/events/interaction-create/slash-command.ts
+++ b/src/events/interaction-create/slash-command.ts
@@ -1,6 +1,5 @@
-import type { ChatInputCommandInteraction, Client } from "discord.js";
+import type { ChatInputCommandInteraction } from "discord.js";
 import type { InteractionCreateEvent } from "../../handlers/interactionCreateEvents.handler";
-import type { SlashCommand } from "../../handlers/slashCommands.handler";
 
 const replyError = async (
   interaction: ChatInputCommandInteraction,
@@ -18,27 +17,16 @@ const replyError = async (
   }
 };
 
-const searchSlashCommand = (
-  client: Client,
-  interaction: ChatInputCommandInteraction,
-): SlashCommand | undefined => {
-  const { commandName } = interaction;
-  const subcommandGroupName = interaction.options.getSubcommandGroup();
-  const subcommandName = interaction.options.getSubcommand(false);
-  const searchCommandName = [commandName, subcommandGroupName, subcommandName]
-    .filter((name) => name)
-    .join(" ");
-  console.log(searchCommandName);
-  return client.slashCommands.get(searchCommandName);
-};
-
 const event: InteractionCreateEvent = {
   execute: async (client, interaction) => {
     if (!interaction.isChatInputCommand()) {
       return;
     }
 
-    const command = searchSlashCommand(client, interaction);
+    const { commandName } = interaction;
+    console.log(commandName);
+    const command = client.slashCommands.get(commandName);
+
     if (!command) {
       console.error(
         `No command matching ${interaction.commandName} was found.`,


### PR DESCRIPTION
# Pull Request

## Related Issue

Not applicable

## Description

Prior to this commit, we have builder in `SlashCommand` which will cause inconsistent in creating slash commands.

Start from this commit, developers don't need to create the builder themselves. They only need to define the properties and handler function will do the builder creation.

## Checklist

Before submitting this PR, please make sure you've done the following:

- [ ] Linked the related issue(s) above.
- [x] Run `npm run lint` and fixed any linting errors.
- [x] Run `npm run format` to ensure code formatting compliance.

### Additional Checklist (if applicable)

- [x] Reviewed the code for any potential security concerns.
- [ ] Documented any new or changed functionality.

## Screenshots (if applicable)

If applicable, please include screenshots or GIFs to illustrate the changes.

## Reviewers

Please request a review from one or more reviewers. You can @mention them below:

@reviewer1
@reviewer2

## Additional Notes

Any additional information or context you would like to provide about this PR.
